### PR TITLE
Graph 256 - Transaction Handler

### DIFF
--- a/chain/tendermint/proto/codec.proto
+++ b/chain/tendermint/proto/codec.proto
@@ -42,6 +42,11 @@ message EventData {
   EventBlock  block = 2;
 }
 
+message TransactionData {
+  TxResult   tx    = 1;
+  EventBlock block = 2;
+}
+
 message Block {
   Header        header      = 1 [(gogoproto.nullable) = false];
   Data          data        = 2 [(gogoproto.nullable) = false];

--- a/chain/tendermint/src/chain.rs
+++ b/chain/tendermint/src/chain.rs
@@ -208,6 +208,14 @@ impl TriggersAdapterTrait<Chain> for TriggersAdapter {
             }))
             .collect();
 
+        triggers.append(
+            &mut shared_block
+                .tx_results()
+                .cloned()
+                .map(|tx| TendermintTrigger::with_transaction(tx, block.block().clone()))
+                .collect(),
+        );
+
         triggers.push(TendermintTrigger::Block(shared_block.cheap_clone()));
 
         Ok(BlockWithTriggers::new(block, triggers))

--- a/chain/tendermint/src/codec.rs
+++ b/chain/tendermint/src/codec.rs
@@ -148,11 +148,11 @@ impl BlockchainBlock for EventBlock {
 }
 
 impl TransactionData {
-    pub fn tx(&self) -> &TxResult {
+    pub fn tx_result(&self) -> &TxResult {
         self.tx.as_ref().unwrap()
     }
 
-    pub fn tx_result(&self) -> &ResponseDeliverTx {
+    pub fn response_deliver_tx(&self) -> &ResponseDeliverTx {
         self.tx.as_ref().unwrap().result.as_ref().unwrap()
     }
 

--- a/chain/tendermint/src/codec.rs
+++ b/chain/tendermint/src/codec.rs
@@ -49,6 +49,10 @@ impl EventList {
         })
     }
 
+    pub fn tx_results(&self) -> impl Iterator<Item = &TxResult> {
+        self.transaction.iter().flat_map(|tx| tx.tx_result.iter())
+    }
+
     pub fn end_block_events(&self) -> impl Iterator<Item = &Event> {
         self.block()
             .result_end_block
@@ -140,5 +144,19 @@ impl BlockchainBlock for EventBlock {
 
     fn parent_ptr(&self) -> Option<BlockPtr> {
         self.parent_ptr()
+    }
+}
+
+impl TransactionData {
+    pub fn tx(&self) -> &TxResult {
+        self.tx.as_ref().unwrap()
+    }
+
+    pub fn tx_result(&self) -> &ResponseDeliverTx {
+        self.tx.as_ref().unwrap().result.as_ref().unwrap()
+    }
+
+    pub fn block(&self) -> &EventBlock {
+        self.block.as_ref().unwrap()
     }
 }

--- a/chain/tendermint/src/protobuf/fig.tendermint.codec.v1.rs
+++ b/chain/tendermint/src/protobuf/fig.tendermint.codec.v1.rs
@@ -15,6 +15,13 @@ pub struct EventData {
     pub block: ::core::option::Option<EventBlock>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
+pub struct TransactionData {
+    #[prost(message, optional, tag = "1")]
+    pub tx: ::core::option::Option<TxResult>,
+    #[prost(message, optional, tag = "2")]
+    pub block: ::core::option::Option<EventBlock>,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Block {
     #[prost(message, optional, tag = "1")]
     pub header: ::core::option::Option<Header>,

--- a/chain/tendermint/src/runtime/abi.rs
+++ b/chain/tendermint/src/runtime/abi.rs
@@ -39,6 +39,19 @@ impl ToAscObj<AscEventData> for codec::EventData {
     }
 }
 
+impl ToAscObj<AscTransactionData> for codec::TransactionData {
+    fn to_asc_obj<H: AscHeap + ?Sized>(
+        &self,
+        heap: &mut H,
+        gas: &GasCounter,
+    ) -> Result<AscTransactionData, DeterministicHostError> {
+        Ok(AscTransactionData {
+            tx: asc_new_or_null(heap, &self.tx, gas)?,
+            block: asc_new_or_null(heap, &self.block, gas)?,
+        })
+    }
+}
+
 impl ToAscObj<AscEventBlock> for codec::EventBlock {
     fn to_asc_obj<H: AscHeap + ?Sized>(
         &self,

--- a/chain/tendermint/src/runtime/generated.rs
+++ b/chain/tendermint/src/runtime/generated.rs
@@ -258,6 +258,17 @@ impl AscIndexId for AscEventList {
 
 #[repr(C)]
 #[derive(AscType)]
+pub(crate) struct AscTransactionData {
+    pub tx: AscPtr<AscTxResult>,
+    pub block: AscPtr<AscEventBlock>,
+}
+
+impl AscIndexId for AscTransactionData {
+    const INDEX_ASC_TYPE_ID: IndexForAscTypeId = IndexForAscTypeId::TendermintTransactionData;
+}
+
+#[repr(C)]
+#[derive(AscType)]
 pub(crate) struct AscBlock {
     pub header: AscPtr<AscHeader>,
     pub data: AscPtr<AscData>,

--- a/chain/tendermint/src/trigger.rs
+++ b/chain/tendermint/src/trigger.rs
@@ -163,7 +163,9 @@ impl Ord for TendermintTrigger {
             (Self::Event { .. }, Self::Event { .. }) => Ordering::Equal,
 
             // Transactions are ordered by their index inside the block
-            (Self::Transaction(a), Self::Transaction(b)) => a.tx().index.cmp(&b.tx().index),
+            (Self::Transaction(a), Self::Transaction(b)) => {
+                a.tx_result().index.cmp(&b.tx_result().index)
+            }
 
             // When comparing events and transactions, transactions go first
             (Self::Transaction(..), Self::Event { .. }) => Ordering::Less,
@@ -198,7 +200,7 @@ impl TriggerData for TendermintTrigger {
                     "block #{}, hash {}, transaction log: {}",
                     self.block_number(),
                     self.block_hash(),
-                    transaction_data.tx_result().log
+                    transaction_data.response_deliver_tx().log
                 )
             }
         }

--- a/chain/tendermint/src/trigger.rs
+++ b/chain/tendermint/src/trigger.rs
@@ -18,6 +18,7 @@ impl std::fmt::Debug for TendermintTrigger {
                 event_type: &'e str,
                 origin: EventOrigin,
             },
+            Transaction,
         }
 
         let trigger_without_block = match self {
@@ -26,6 +27,7 @@ impl std::fmt::Debug for TendermintTrigger {
                 event_type: &event_data.event().event_type,
                 origin: *origin,
             },
+            TendermintTrigger::Transaction(_) => MappingTriggerWithoutBlock::Transaction,
         };
 
         write!(f, "{:?}", trigger_without_block)
@@ -45,6 +47,9 @@ impl MappingTrigger for TendermintTrigger {
             TendermintTrigger::Event { event_data, .. } => {
                 asc_new(heap, event_data.as_ref(), gas)?.erase()
             }
+            TendermintTrigger::Transaction(transaction_data) => {
+                asc_new(heap, transaction_data.as_ref(), gas)?.erase()
+            }
         })
     }
 }
@@ -56,6 +61,7 @@ pub enum TendermintTrigger {
         event_data: Arc<codec::EventData>,
         origin: EventOrigin,
     },
+    Transaction(Arc<codec::TransactionData>),
 }
 
 impl CheapClone for TendermintTrigger {
@@ -68,6 +74,9 @@ impl CheapClone for TendermintTrigger {
                 event_data: event_data.cheap_clone(),
                 origin: *origin,
             },
+            TendermintTrigger::Transaction(transaction_data) => {
+                TendermintTrigger::Transaction(transaction_data.cheap_clone())
+            }
         }
     }
 }
@@ -89,6 +98,7 @@ impl PartialEq for TendermintTrigger {
                 a_event_data.event().event_type == b_event_data.event().event_type
                     && a_origin == b_origin
             }
+            (Self::Transaction(a_ptr), Self::Transaction(b_ptr)) => a_ptr == b_ptr,
             _ => false,
         }
     }
@@ -111,10 +121,21 @@ impl TendermintTrigger {
         }
     }
 
+    pub(crate) fn with_transaction(
+        tx_result: codec::TxResult,
+        block: codec::EventBlock,
+    ) -> TendermintTrigger {
+        TendermintTrigger::Transaction(Arc::new(codec::TransactionData {
+            tx: Some(tx_result),
+            block: Some(block),
+        }))
+    }
+
     pub fn block_number(&self) -> BlockNumber {
         match self {
             TendermintTrigger::Block(event_list) => event_list.block().number(),
             TendermintTrigger::Event { event_data, .. } => event_data.block().number(),
+            TendermintTrigger::Transaction(transaction_data) => transaction_data.block().number(),
         }
     }
 
@@ -122,6 +143,7 @@ impl TendermintTrigger {
         match self {
             TendermintTrigger::Block(event_list) => event_list.block().hash(),
             TendermintTrigger::Event { event_data, .. } => event_data.block().hash(),
+            TendermintTrigger::Transaction(transaction_data) => transaction_data.block().hash(),
         }
     }
 }
@@ -139,6 +161,13 @@ impl Ord for TendermintTrigger {
             // Events have no intrinsic ordering information, so we keep the order in
             // which they are included in the `events` field
             (Self::Event { .. }, Self::Event { .. }) => Ordering::Equal,
+
+            // Transactions are ordered by their index inside the block
+            (Self::Transaction(a), Self::Transaction(b)) => a.tx().index.cmp(&b.tx().index),
+
+            // When comparing events and transactions, transactions go first
+            (Self::Transaction(..), Self::Event { .. }) => Ordering::Less,
+            (Self::Event { .. }, Self::Transaction(..)) => Ordering::Greater,
         }
     }
 }
@@ -162,6 +191,14 @@ impl TriggerData for TendermintTrigger {
                     origin,
                     self.block_number(),
                     self.block_hash(),
+                )
+            }
+            TendermintTrigger::Transaction(transaction_data) => {
+                format!(
+                    "block #{}, hash {}, transaction log: {}",
+                    self.block_number(),
+                    self.block_hash(),
+                    transaction_data.tx_result().log
                 )
             }
         }

--- a/graph/src/runtime/mod.rs
+++ b/graph/src/runtime/mod.rs
@@ -307,6 +307,9 @@ pub enum IndexForAscTypeId {
     Log = 135,
     ArrayH256 = 136,
     ArrayLog = 137,
+
+    //Tendermint transaction data type
+    TendermintTransactionData = 139,
 }
 
 impl ToAscObj<u32> for IndexForAscTypeId {

--- a/graph/src/runtime/mod.rs
+++ b/graph/src/runtime/mod.rs
@@ -309,7 +309,7 @@ pub enum IndexForAscTypeId {
     ArrayLog = 137,
 
     //Tendermint transaction data type
-    TendermintTransactionData = 139,
+    TendermintTransactionData = 138,
 }
 
 impl ToAscObj<u32> for IndexForAscTypeId {


### PR DESCRIPTION
[GRAPH-256](https://figmentio.atlassian.net/browse/GRAPH-256)

- Created a new `TendermintTrigger` to process transactions. This allows the `tendermint` subgraphs to include a new type of mapping named `transactionHandler` that will process individual transactions.
- In order to test this a new subgraph can be created using the new mapping. Also, the changes in branch GRAPH-256 for `graph-cli` and `tendermint-protobuf-def` need to be checked out to get the new proto structure `TransactionData`.