### PR TITLE
Use HeaderOnlyBlock wherever possible

### DIFF
--- a/chain/cosmos/src/chain.rs
+++ b/chain/cosmos/src/chain.rs
@@ -159,7 +159,7 @@ impl Blockchain for Chain {
         };
 
         firehose_endpoint
-            .block_ptr_for_number::<codec::Block>(logger, number)
+            .block_ptr_for_number::<codec::HeaderOnlyBlock>(logger, number)
             .await
             .map_err(Into::into)
     }
@@ -340,7 +340,7 @@ impl FirehoseMapperTrait<Chain> for FirehoseMapper {
         number: BlockNumber,
     ) -> Result<BlockPtr, Error> {
         self.endpoint
-            .block_ptr_for_number::<codec::Block>(logger, number)
+            .block_ptr_for_number::<codec::HeaderOnlyBlock>(logger, number)
             .await
     }
 
@@ -351,7 +351,7 @@ impl FirehoseMapperTrait<Chain> for FirehoseMapper {
     ) -> Result<BlockPtr, Error> {
         // Cosmos provides instant block finality.
         self.endpoint
-            .block_ptr_for_number::<codec::Block>(logger, block.number())
+            .block_ptr_for_number::<codec::HeaderOnlyBlock>(logger, block.number())
             .await
     }
 }


### PR DESCRIPTION
After reviewing the code I see that there is almost no update needed to include the HeaderOnlyBlock structure. We just need to update a couple of methods included in this PR. 
Protos use `HeaderOnlyBlock` for `EventData` and `TransactionData`, triggers use `HeaderOnlyBlock`, codec implements `HeaderOnlyBlock` for `EventData` and `TransactionData` implementations (i.e. when returning the a reference to the block). So I think we have everything covered.