### PR TITLE
Pass a transaction context to the message handler and event handler

### DIFF
--- a/chain/common/src/lib.rs
+++ b/chain/common/src/lib.rs
@@ -12,7 +12,7 @@ use protobuf::UnknownValueRef;
 use std::convert::From;
 use std::path::Path;
 
-const REQUIRED_ID: u32 = 66001;
+const REQUIRED_ID: u32 = 77001;
 
 #[derive(Debug, Clone)]
 pub struct Field {

--- a/chain/common/tests/resources/firehose/annotations.proto
+++ b/chain/common/tests/resources/firehose/annotations.proto
@@ -1,9 +1,11 @@
+syntax = "proto3";
+
 package firehose;
+
+option go_package = "github.com/streamingfast/pbgo/sf/firehose/v1;pbfirehose";
 
 import "google/protobuf/descriptor.proto";
 
-// 66K range is arbitrary picked number, might be conflict
-
 extend google.protobuf.FieldOptions {
-  optional bool required = 66001;
+  optional bool required = 77001;
 }

--- a/chain/cosmos/proto/firehose/annotations.proto
+++ b/chain/cosmos/proto/firehose/annotations.proto
@@ -1,9 +1,11 @@
+syntax = "proto3";
+
 package firehose;
+
+option go_package = "github.com/streamingfast/pbgo/sf/firehose/v1;pbfirehose";
 
 import "google/protobuf/descriptor.proto";
 
-// 66K range is arbitrary picked number, might be conflict
-
 extend google.protobuf.FieldOptions {
-  optional bool required = 66001;
+  optional bool required = 77001;
 }

--- a/chain/cosmos/proto/type.proto
+++ b/chain/cosmos/proto/type.proto
@@ -33,6 +33,7 @@ message HeaderOnlyBlock {
 message EventData {
   Event event = 1 [(firehose.required) = true];
   HeaderOnlyBlock block = 2 [(firehose.required) = true];
+  TransactionContext tx = 3;
 }
 
 message TransactionData {
@@ -41,8 +42,17 @@ message TransactionData {
 }
 
 message MessageData {
-  google.protobuf.Any message = 1;
-  HeaderOnlyBlock block = 2;
+  google.protobuf.Any message = 1 [(firehose.required) = true];
+  HeaderOnlyBlock block = 2 [(firehose.required) = true];
+  TransactionContext tx = 3 [(firehose.required) = true];
+}
+
+message TransactionContext {
+  bytes hash = 1;
+  uint32 index = 2;
+  uint32 code = 3;
+  int64 gas_wanted = 4;
+  int64 gas_used = 5;
 }
 
 message Header {

--- a/chain/cosmos/src/codec.rs
+++ b/chain/cosmos/src/codec.rs
@@ -15,15 +15,6 @@ impl Block {
             .ok_or_else(|| anyhow!("block data missing header field"))
     }
 
-    pub fn events(&self) -> Result<impl Iterator<Item = &Event>, Error> {
-        let events = self
-            .begin_block_events()?
-            .chain(self.tx_events()?)
-            .chain(self.end_block_events()?);
-
-        Ok(events)
-    }
-
     pub fn begin_block_events(&self) -> Result<impl Iterator<Item = &Event>, Error> {
         let events = self
             .result_begin_block
@@ -31,22 +22,6 @@ impl Block {
             .ok_or_else(|| anyhow!("block data missing result_begin_block field"))?
             .events
             .iter();
-
-        Ok(events)
-    }
-
-    pub fn tx_events(&self) -> Result<impl Iterator<Item = &Event>, Error> {
-        if self.transactions.iter().any(|tx| tx.result.is_none()) {
-            return Err(anyhow!("block data transaction missing result field"));
-        }
-
-        let events = self.transactions.iter().flat_map(|tx| {
-            tx.result
-                .as_ref()
-                .map(|b| b.events.iter())
-                .into_iter()
-                .flatten()
-        });
 
         Ok(events)
     }

--- a/chain/cosmos/src/protobuf/sf.cosmos.r#type.v1.rs
+++ b/chain/cosmos/src/protobuf/sf.cosmos.r#type.v1.rs
@@ -41,6 +41,8 @@ pub struct EventData {
     pub event: ::core::option::Option<Event>,
     #[prost(message, optional, tag="2")]
     pub block: ::core::option::Option<HeaderOnlyBlock>,
+    #[prost(message, optional, tag="3")]
+    pub tx: ::core::option::Option<TransactionContext>,
 }
 #[graph_runtime_derive::generate_asc_type(__required__{tx: TxResult,block: HeaderOnlyBlock})]
 #[graph_runtime_derive::generate_network_type_id(Cosmos)]
@@ -52,15 +54,33 @@ pub struct TransactionData {
     #[prost(message, optional, tag="2")]
     pub block: ::core::option::Option<HeaderOnlyBlock>,
 }
-#[graph_runtime_derive::generate_asc_type()]
+#[graph_runtime_derive::generate_asc_type(__required__{message: Any,block: HeaderOnlyBlock,tx: TransactionContext})]
 #[graph_runtime_derive::generate_network_type_id(Cosmos)]
-#[graph_runtime_derive::generate_from_rust_type()]
+#[graph_runtime_derive::generate_from_rust_type(__required__{message: Any,block: HeaderOnlyBlock,tx: TransactionContext})]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct MessageData {
     #[prost(message, optional, tag="1")]
     pub message: ::core::option::Option<::prost_types::Any>,
     #[prost(message, optional, tag="2")]
     pub block: ::core::option::Option<HeaderOnlyBlock>,
+    #[prost(message, optional, tag="3")]
+    pub tx: ::core::option::Option<TransactionContext>,
+}
+#[graph_runtime_derive::generate_asc_type()]
+#[graph_runtime_derive::generate_network_type_id(Cosmos)]
+#[graph_runtime_derive::generate_from_rust_type()]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct TransactionContext {
+    #[prost(bytes="vec", tag="1")]
+    pub hash: ::prost::alloc::vec::Vec<u8>,
+    #[prost(uint32, tag="2")]
+    pub index: u32,
+    #[prost(uint32, tag="3")]
+    pub code: u32,
+    #[prost(int64, tag="4")]
+    pub gas_wanted: i64,
+    #[prost(int64, tag="5")]
+    pub gas_used: i64,
 }
 #[graph_runtime_derive::generate_asc_type(__required__{last_block_id: BlockID})]
 #[graph_runtime_derive::generate_network_type_id(Cosmos)]

--- a/chain/cosmos/src/runtime/mod.rs
+++ b/chain/cosmos/src/runtime/mod.rs
@@ -64,11 +64,26 @@ mod test {
         assert_asc_bytes!(AscEventData {
             event: new_asc_ptr(),
             block: new_asc_ptr(),
+            tx: new_asc_ptr(),
         });
 
         assert_asc_bytes!(AscTransactionData {
             tx: new_asc_ptr(),
             block: new_asc_ptr(),
+        });
+
+        assert_asc_bytes!(AscMessageData {
+            message: new_asc_ptr(),
+            block: new_asc_ptr(),
+            tx: new_asc_ptr(),
+        });
+
+        assert_asc_bytes!(AscTransactionContext {
+            hash: new_asc_ptr(),
+            index: 20,
+            code: 20,
+            gas_wanted: 20,
+            gas_used: 20,
         });
 
         assert_asc_bytes!(AscHeader {

--- a/chain/cosmos/src/trigger.rs
+++ b/chain/cosmos/src/trigger.rs
@@ -120,12 +120,14 @@ impl CosmosTrigger {
     pub(crate) fn with_event(
         event: codec::Event,
         block: codec::HeaderOnlyBlock,
+        tx_context: Option<codec::TransactionContext>,
         origin: EventOrigin,
     ) -> CosmosTrigger {
         CosmosTrigger::Event {
             event_data: Arc::new(codec::EventData {
                 event: Some(event),
                 block: Some(block),
+                tx: tx_context,
             }),
             origin,
         }
@@ -144,10 +146,12 @@ impl CosmosTrigger {
     pub(crate) fn with_message(
         message: ::prost_types::Any,
         block: codec::HeaderOnlyBlock,
+        tx_context: codec::TransactionContext,
     ) -> CosmosTrigger {
         CosmosTrigger::Message(Arc::new(codec::MessageData {
             message: Some(message),
             block: Some(block),
+            tx: Some(tx_context),
         }))
     }
 

--- a/graph/src/runtime/mod.rs
+++ b/graph/src/runtime/mod.rs
@@ -331,10 +331,11 @@ pub enum IndexForAscTypeId {
     CosmosValidatorUpdate = 1560,
     CosmosVersionParams = 1561,
     CosmosMessageData = 1562,
+    CosmosTransactionContext = 1563,
     // Continue to add more Cosmos type IDs here.
     // e.g.:
-    // NextCosmosType = 1563,
-    // AnotherCosmosType = 1564,
+    // NextCosmosType = 1564,
+    // AnotherCosmosType = 1565,
     // ...
     // LastCosmosType = 2499,
 


### PR DESCRIPTION
As mentioned in #43, passing the whole transaction object has a negative impact on the indexing performance. This PR adds a transaction context, which is a lightweight structure that contains only the most important fields:
* transaction hash
* transaction index
* status code
* gas information